### PR TITLE
Adding /etc/init.d daemon script for raspberry pi and install script for raspi

### DIFF
--- a/flicd.initd
+++ b/flicd.initd
@@ -1,0 +1,96 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          flicd 
+# Required-Start:    $local_fs $network $named $time $syslog
+# Required-Stop:     $local_fs $network $named $time $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Description:       flic daemon
+### END INIT INFO
+
+SCRIPT="/usr/sbin/flicd -f /var/lib/flic/flic.sqlite3 -s 0.0.0.0 -d"
+RUNAS=root
+
+PIDFILE=/var/run/flicd.pid
+LOGFILE=/var/log/flicd.log
+
+start() {
+  if [ -f $PIDFILE ] && [ -s $PIDFILE ] && kill -0 $(cat $PIDFILE); then
+    echo 'Service already running' >&2
+    return 1
+  fi
+  echo 'Starting service…' >&2
+  local CMD="$SCRIPT &> \"$LOGFILE\" & echo \$!"
+  su -c "$CMD" $RUNAS > "$PIDFILE"
+ # Try with this command line instead of above if not workable
+ # su -s /bin/sh $RUNAS -c "$CMD" > "$PIDFILE"
+ 
+  sleep 2
+  PID=$(cat $PIDFILE)
+    if pgrep -u $RUNAS -f $NAME > /dev/null
+    then
+      echo "$NAME is now running, the PID is $PID"
+    else
+      echo ''
+      echo "Error! Could not start $NAME!"
+    fi
+}
+
+stop() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE"); then
+    echo 'Service not running' >&2
+    return 1
+  fi
+  echo 'Stopping service…' >&2
+  kill -15 $(cat "$PIDFILE") && rm -f "$PIDFILE"
+  echo 'Service stopped' >&2
+}
+
+uninstall() {
+  echo -n "Are you really sure you want to uninstall this service? That cannot be undone. [yes|No] "
+  local SURE
+  read SURE
+  if [ "$SURE" = "yes" ]; then
+    stop
+    rm -f "$PIDFILE"
+    echo "Notice: log file was not removed: $LOGFILE" >&2
+    update-rc.d -f $NAME remove
+    rm -fv "$0"
+  fi
+}
+
+status() {
+    printf "%-50s" "Checking <NAME>..."
+    if [ -f $PIDFILE ] && [ -s $PIDFILE ]; then
+        PID=$(cat $PIDFILE)
+            if [ -z "$(ps axf | grep ${PID} | grep -v grep)" ]; then
+                printf "%s\n" "The process appears to be dead but pidfile still exists"
+            else    
+                echo "Running, the PID is $PID"
+            fi
+    else
+        printf "%s\n" "Service not running"
+    fi
+}
+
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  status)
+    status
+    ;;
+  uninstall)
+    uninstall
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|status|restart|uninstall}"
+esac

--- a/install-raspi.sh
+++ b/install-raspi.sh
@@ -5,7 +5,7 @@ curl https://raw.githubusercontent.com/50ButtonsEach/fliclib-linux-hci/master/bi
 chmod a+x /usr/sbin/flicd
 
 # Download the latest init script
-#curl https://scscsc > /etc/init.d/flicd
+curl https://raw.githubusercontent.com/50ButtonsEach/fliclib-linux-hci/master/flicd.initd > /etc/init.d/flicd
 chmod a+x /etc/init.d/flicd
 
 # Disable old bluetooth daemon

--- a/install-raspi.sh
+++ b/install-raspi.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Download the latest flic binary
+curl https://raw.githubusercontent.com/50ButtonsEach/fliclib-linux-hci/master/bin/armv6l/flicd > /usr/sbin/flicd
+chmod a+x /usr/sbin/flicd
+
+# Download the latest init script
+#curl https://scscsc > /etc/init.d/flicd
+chmod a+x /etc/init.d/flicd
+
+# Disable old bluetooth daemon
+sudo systemctl disable bluetooth
+sudo systemctl stop bluetooth
+
+# Enable flicd
+mkdir /var/lib/flic
+sudo systemctl enable flicd
+sudo systemctl start flicd
+


### PR DESCRIPTION
This patch adds two files. One is the /etc/init.d/flicd file for adding the flicd as a system daemon with start and stop, the other one is a very simple install script for raspberry pi.