### PR TITLE
Avoids deprecation warning using Buffer

### DIFF
--- a/clientlib/nodejs/fliclibNodeJs.js
+++ b/clientlib/nodejs/fliclibNodeJs.js
@@ -51,7 +51,7 @@ var FlicEventOpcodes = {
 
 function createBuffer(arr, offset, len) {
 	arr = new Uint8Array(arr, offset, len);
-	return Buffer.from(arr);
+	return Buffer.allocUnsafe ? Buffer.from(arr) : new Buffer(arr);
 }
 
 /**

--- a/clientlib/nodejs/fliclibNodeJs.js
+++ b/clientlib/nodejs/fliclibNodeJs.js
@@ -51,7 +51,7 @@ var FlicEventOpcodes = {
 
 function createBuffer(arr, offset, len) {
 	arr = new Uint8Array(arr, offset, len);
-	return new Buffer(arr);
+	return Buffer.from(arr);
 }
 
 /**


### PR DESCRIPTION
Hopefully this is useful - I was getting a deprecation/security warning using the node library and reading js docs suggests going with Buffer.from is the way to go.